### PR TITLE
Fixed `pyairctrl.http_air_client` references to `pyairctrl.http_client`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # 0.1.2 (upcoming)
 
 - Removed the `py-air-control-exporter` entry point.
+- Fixed `pyairctrl.http_air_client` references to `pyairctrl.http_client`.
 
 # 0.1.1
 

--- a/py_air_control_exporter/metrics.py
+++ b/py_air_control_exporter/metrics.py
@@ -2,7 +2,7 @@ import logging
 from os import environ
 
 import prometheus_client.core
-from pyairctrl import coap_client, http_air_client, plain_coap_client
+from pyairctrl import coap_client, http_client, plain_coap_client
 
 HOST_ENV_VAR = "PY_AIR_CONTROL_HOST"
 PROTOCOL_ENV_VAR = "PY_AIR_CONTROL_PROTOCOL"
@@ -77,7 +77,7 @@ def get_status():
 
 def get_client(protocol, host):
     if protocol == HTTP_PROTOCOL:
-        return http_air_client.HTTPAirClient(host)
+        return http_client.HTTPAirClient(host)
     if protocol == COAP_PROTOCOL:
         return coap_client.CoAPAirClient(host)
     if protocol == PLAIN_COAP_PROTOCOL:

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ from setuptools import setup, find_packages
 
 REQUIREMENTS = [
     "Flask>=1.0.0",
-    "prometheus_client>=0.9.0",
+    "prometheus_client>=0.8.0",
     "py-air-control>=2.0.0",
 ]
 


### PR DESCRIPTION
This change also relaxes the dependency version of prometheus_client and removes the need for internet connectivity during unit tests.